### PR TITLE
fix: Don't panic if the server returns 0 as the quota limit

### DIFF
--- a/src/types/quota.rs
+++ b/src/types/quota.rs
@@ -48,7 +48,11 @@ impl From<QuotaResourceRef<'_>> for QuotaResource {
 impl QuotaResource {
     /// Returns the usage percentage of a QuotaResource.
     pub fn get_usage_percentage(&self) -> u64 {
-        self.usage.saturating_mul(100) / self.limit
+        self.usage
+            .saturating_mul(100)
+            .checked_div(self.limit)
+            // Assume that if `limit` is 0, this means that storage is unlimited:
+            .unwrap_or(0)
     }
 }
 


### PR DESCRIPTION
This is for https://github.com/chatmail/core/issues/6629.

The connectivity view will look like this in Delta Chat:

![Screenshot_20250310-181004](https://github.com/user-attachments/assets/12751bc9-43a2-459b-9427-d555d2fd5c31)

cc @dlukt @adbenitez - thanks for reporting & bringing attenntion to it!