### PR TITLE
chore: remove futures dependency, depend on futures-util/io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ async-std = { version = "1.8.0", default-features = false, features = ["std", "u
 base64 = "0.22.1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
-futures = "0.3.15"
+futures-util = {version = "0.3.15", features = ["io"] }
 imap-proto = "0.16.4"
 log = "0.4.8"
 nom = "7.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,5 +19,6 @@ async-native-tls = { version = "0.5", default-features = false }
 async-smtp = { version = "0.8", default-features = false }
 
 async-std = { version = "1.12.0", features = ["std", "attributes"], optional = true }
-futures = "0.3.28"
+futures-executor = "0.3.28"
+futures-util = "0.3.28"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,4 +12,4 @@ Examples:
 * gmail_oauth2 - This is an example using oauth2 for logging into
   gmail via the OAUTH2 mechanism.
 
-* futures - The basic example, but using the `futures` executor.
+* futures - The basic example, but using the `futures` (`futures-executor`) executor.

--- a/examples/src/bin/basic.rs
+++ b/examples/src/bin/basic.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use anyhow::{bail, Result};
-use futures::TryStreamExt;
+use futures_util::TryStreamExt;
 
 #[cfg(feature = "runtime-async-std")]
 use async_std::net::TcpStream;

--- a/examples/src/bin/futures.rs
+++ b/examples/src/bin/futures.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use anyhow::{bail, Result};
-use futures::TryStreamExt;
+use futures_util::TryStreamExt;
 
 #[cfg(feature = "runtime-async-std")]
 use async_std::net::TcpStream;
@@ -9,7 +9,7 @@ use async_std::net::TcpStream;
 use tokio::net::TcpStream;
 
 fn main() -> Result<()> {
-    futures::executor::block_on(async {
+    futures_executor::block_on(async {
         let args: Vec<String> = env::args().collect();
         if args.len() != 4 {
             eprintln!("need three arguments: imap-server login password");

--- a/examples/src/bin/gmail_oauth2.rs
+++ b/examples/src/bin/gmail_oauth2.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use futures::StreamExt;
+use futures_util::StreamExt;
 
 #[cfg(feature = "runtime-async-std")]
 use async_std::net::TcpStream;

--- a/examples/src/bin/idle.rs
+++ b/examples/src/bin/idle.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::{bail, Result};
 use async_imap::extensions::idle::IdleResponse::*;
-use futures::StreamExt;
+use futures_util::StreamExt;
 
 #[cfg(feature = "runtime-async-std")]
 use async_std::{net::TcpStream, task, task::sleep};

--- a/examples/src/bin/integration.rs
+++ b/examples/src/bin/integration.rs
@@ -7,7 +7,7 @@ use async_native_tls::TlsConnector;
 use async_smtp::{SendableEmail, SmtpClient, SmtpTransport};
 #[cfg(feature = "runtime-async-std")]
 use async_std::{net::TcpStream, task, task::sleep};
-use futures::{StreamExt, TryStreamExt};
+use futures_util::{StreamExt, TryStreamExt};
 #[cfg(feature = "runtime-tokio")]
 use tokio::{net::TcpStream, task, time::sleep};
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,7 @@ use async_std::io::{Read, Write, WriteExt};
 use base64::Engine as _;
 use extensions::id::{format_identification, parse_id};
 use extensions::quota::parse_get_quota_root;
-use futures::{Stream, TryStreamExt, io};
+use futures_util::{Stream, TryStreamExt, io};
 use imap_proto::{Metadata, RequestId, Response};
 #[cfg(feature = "runtime-tokio")]
 use tokio::io::{AsyncRead as Read, AsyncWrite as Write, AsyncWriteExt};
@@ -807,7 +807,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Session<T> {
     /// use async_std::net::TcpStream;
     /// #[cfg(feature = "runtime-tokio")]
     /// use tokio::net::TcpStream;
-    /// use futures::TryStreamExt;
+    /// use futures_util::TryStreamExt;
     ///
     /// async fn delete(seq: Seq, s: &mut Session<TcpStream>) -> Result<()> {
     ///     let updates_stream = s.store(format!("{}", seq), "+FLAGS (\\Deleted)").await?;
@@ -1528,7 +1528,7 @@ mod tests {
     use std::future::Future;
 
     use async_std::sync::{Arc, Mutex};
-    use futures::StreamExt;
+    use futures_util::StreamExt;
     use imap_proto::Status;
 
     macro_rules! mock_client {
@@ -2371,7 +2371,7 @@ mod tests {
         tokio::test(flavor = "multi_thread", worker_threads = 2)
     )]
     async fn large_fetch() -> Result<()> {
-        use futures::TryStreamExt;
+        use futures_util::TryStreamExt;
 
         let (client, server) = tokio::io::duplex(4096);
         tokio::spawn(handle_client(server));

--- a/src/extensions/compress.rs
+++ b/src/extensions/compress.rs
@@ -15,7 +15,7 @@ use crate::types::IdGenerator;
 #[cfg(feature = "runtime-async-std")]
 use async_std::io::{IoSlice, IoSliceMut, Read, Write};
 #[cfg(feature = "runtime-async-std")]
-use futures::io::BufReader;
+use futures_util::io::BufReader;
 #[cfg(feature = "runtime-tokio")]
 use tokio::io::{AsyncRead as Read, AsyncWrite as Write, BufReader, ReadBuf};
 

--- a/src/extensions/id.rs
+++ b/src/extensions/id.rs
@@ -1,8 +1,7 @@
 //! IMAP ID extension specified in [RFC2971](https://datatracker.ietf.org/doc/html/rfc2971)
 
 use async_channel as channel;
-use futures::io;
-use futures::prelude::*;
+use futures_util::{Stream, StreamExt as _, TryStreamExt as _, io};
 use imap_proto::{self, RequestId, Response};
 use std::collections::HashMap;
 

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -9,8 +9,10 @@ use async_std::{
     future::timeout,
     io::{Read, Write},
 };
-use futures::prelude::*;
-use futures::task::{Context, Poll};
+use futures_util::{
+    Stream, StreamExt as _, TryStreamExt as _,
+    task::{Context, Poll},
+};
 use imap_proto::{RequestId, Response, Status};
 use stop_token::prelude::*;
 #[cfg(feature = "runtime-tokio")]
@@ -72,7 +74,9 @@ impl<'a, St: Stream + Unpin> IdleStream<'a, St> {
     }
 }
 
-impl<St: futures::stream::FusedStream + Unpin> futures::stream::FusedStream for IdleStream<'_, St> {
+impl<St: futures_util::stream::FusedStream + Unpin> futures_util::stream::FusedStream
+    for IdleStream<'_, St>
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/src/extensions/quota.rs
+++ b/src/extensions/quota.rs
@@ -1,8 +1,7 @@
 //! Adds support for the GETQUOTA and GETQUOTAROOT commands specificed in [RFC2087](https://tools.ietf.org/html/rfc2087).
 
 use async_channel as channel;
-use futures::io;
-use futures::prelude::*;
+use futures_util::{Stream, StreamExt as _, TryStreamExt as _, io};
 use imap_proto::{self, RequestId, Response};
 
 use crate::types::*;

--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -4,9 +4,9 @@ use std::pin::Pin;
 #[cfg(feature = "runtime-async-std")]
 use async_std::io::{Read, Write, WriteExt};
 use bytes::BytesMut;
-use futures::stream::Stream;
-use futures::task::{Context, Poll};
-use futures::{io, ready};
+use futures_util::stream::Stream;
+use futures_util::task::{Context, Poll};
+use futures_util::{io, ready};
 use nom::Needed;
 #[cfg(feature = "runtime-tokio")]
 use tokio::io::{AsyncRead as Read, AsyncWrite as Write, AsyncWriteExt};
@@ -464,7 +464,7 @@ mod tests {
     #[cfg_attr(feature = "runtime-tokio", tokio::test)]
     #[cfg_attr(feature = "runtime-async-std", async_std::test)]
     async fn test_imap_stream_error() {
-        use futures::StreamExt;
+        use futures_util::StreamExt;
 
         let mock_stream = FailingStream::new(b"* OK\r\n");
         let mut imap_stream = ImapStream::new(mock_stream);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,9 +1,8 @@
 use std::collections::HashSet;
 
 use async_channel as channel;
-use futures::io;
-use futures::prelude::*;
-use futures::stream::Stream;
+use futures_util::stream::Stream;
+use futures_util::{StreamExt as _, TryStreamExt as _, io};
 use imap_proto::{self, MailboxDatum, Metadata, RequestId, Response};
 
 use crate::error::{Error, Result};
@@ -15,7 +14,7 @@ pub(crate) fn parse_names<T: Stream<Item = io::Result<ResponseData>> + Unpin + S
     unsolicited: channel::Sender<UnsolicitedResponse>,
     command_tag: RequestId,
 ) -> impl Stream<Item = Result<Name>> + '_ + Send + Unpin {
-    use futures::{FutureExt, StreamExt};
+    use futures_util::{FutureExt, StreamExt};
 
     StreamExt::filter_map(
         StreamExt::take_while(stream, move |res| filter(res, &command_tag)),
@@ -46,7 +45,7 @@ pub(crate) fn filter(
     command_tag: &RequestId,
 ) -> impl Future<Output = bool> + use<> {
     let val = filter_sync(res, command_tag);
-    futures::future::ready(val)
+    futures_util::future::ready(val)
 }
 
 pub(crate) fn filter_sync(res: &io::Result<ResponseData>, command_tag: &RequestId) -> bool {
@@ -67,7 +66,7 @@ pub(crate) fn parse_fetches<T: Stream<Item = io::Result<ResponseData>> + Unpin +
     unsolicited: channel::Sender<UnsolicitedResponse>,
     command_tag: RequestId,
 ) -> impl Stream<Item = Result<Fetch>> + '_ + Send + Unpin {
-    use futures::{FutureExt, StreamExt};
+    use futures_util::{FutureExt, StreamExt};
 
     StreamExt::filter_map(
         StreamExt::take_while(stream, move |res| filter(res, &command_tag)),
@@ -159,7 +158,7 @@ pub(crate) fn parse_expunge<T: Stream<Item = io::Result<ResponseData>> + Unpin +
     unsolicited: channel::Sender<UnsolicitedResponse>,
     command_tag: RequestId,
 ) -> impl Stream<Item = Result<u32>> + '_ + Send {
-    use futures::StreamExt;
+    use futures_util::StreamExt;
 
     StreamExt::filter_map(
         StreamExt::take_while(stream, move |res| filter(res, &command_tag)),


### PR DESCRIPTION
`futures-util` is a smaller dependency. there is no prelude but it' just 1 or 2 trait imports